### PR TITLE
Working on usability with .py scripts

### DIFF
--- a/src/gitcomp/__init__.py
+++ b/src/gitcomp/__init__.py
@@ -1,11 +1,13 @@
 from .gitcomp_core import GitComp
 from .user import User
 from .repository import Repository
-from .ser_de import Writer
+from .ser_de import Writer, PROP, FIELD
 
 __all__ = [
     'GitComp',
     'User',
     'Repository',
-    'Writer'
+    'Writer',
+    'PROP',
+    'FIELD'
 ]

--- a/src/gitcomp/__main__.py
+++ b/src/gitcomp/__main__.py
@@ -55,8 +55,7 @@ def __get_arg_parser() -> argparse.ArgumentParser:
                         help='''
                             -o, --output <out_file>
                             Output to out_file, defaults to STDOUT.
-                        '''
-                        )
+                        ''')
 
     return parser
 
@@ -77,10 +76,9 @@ def main():
         prop = PROP['users'].value
     elif args.repo_names is not None:
         prop = PROP['repos'].value
-    tp = args.out_type[0]
-    out = args.output_file[0]
-    w = Writer(obj=g, out_type=tp, out_file=out, prop=prop)
-    w.write()
+    out_type = args.out_type[0]
+    out_file = args.output_file[0]
+    Writer(obj=g, out_type=out_type, out_file=out_file, prop=prop).write()
 
 
 if __name__ == '__main__':

--- a/src/gitcomp/repository.py
+++ b/src/gitcomp/repository.py
@@ -26,7 +26,7 @@ class Repository:
     subscribers_count: int
     git_score: int
     license: str = None
-    display_rows = ['full_name', 'forks', 'open_issues', 'watches', 'network_count', 'subscribers_count', 'git_score']
+    display_rows = ['forks', 'open_issues', 'watches', 'network_count', 'subscribers_count', 'git_score']
     __date_fmt = '%Y-%m-%dT%H:%M:%SZ'
     __total_weight = 100 / 16
 

--- a/src/gitcomp/ser_de.py
+++ b/src/gitcomp/ser_de.py
@@ -96,10 +96,11 @@ class Writer:
 
     @writer_wrapper
     def __to_ascii_table(self, g: Dict[str, Union[User, Repository]]):
+        headers, rows = Writer.__get_table_content(g)
         if len(g.keys()) < Writer.__ascii_threshold:
-            table_writer = self.__get_table_transpose(g)
+            table_writer = self.__get_table_transpose(g, headers, rows)
         else:
-            table_writer = self.__get_table(g)
+            table_writer = self.__get_table(headers, rows)
         self.file_handle.write(table_writer)
 
     @writer_wrapper
@@ -118,14 +119,12 @@ class Writer:
         return list(g[members[0]].keys())
 
     @staticmethod
-    def __get_table_transpose(g: Dict[str, Union[User, Repository]]):
-        headers, rows = Writer.__get_table_content(g)
+    def __get_table_transpose(g: Dict[str, Union[User, Repository]], headers: List[str], rows: List[str]):
         new_headers, new_rows = Writer.__get_transpose(g, rows, headers)
         return tabulate(new_rows, headers=new_headers, tablefmt='pretty')
 
     @staticmethod
-    def __get_table(g: Dict[str, Union[User, Repository]]):
-        headers, rows = Writer.__get_table_content(g)
+    def __get_table(headers: List[str], rows: List[str]):
         return tabulate(rows, headers=headers, tablefmt='plain')
 
     @staticmethod
@@ -145,7 +144,7 @@ class Writer:
     @staticmethod
     def __get_transpose(g: Dict[str, Union[User, Repository]], rows, headers):
         new_rows = []
-        new_headers = ['Argument'] + list(g.keys())
+        new_headers = [' '] + list(g.keys())
         for i in range(len(rows[0])):
             new_rows.append([rows[j][i] for j in range(len(rows))])
         for i in range(len(new_rows)):

--- a/src/gitcomp/ser_de.py
+++ b/src/gitcomp/ser_de.py
@@ -40,7 +40,6 @@ def writer_wrapper(writer):
         writer(ref, g)
         if ref.file_handle is stdout:
             ref.file_handle.write('\n')
-        ref.close_file_handle()
 
     return wrapper
 
@@ -69,6 +68,10 @@ class Writer:
         if out_file is not None:
             self.out_file = out_file
             self.file_handle = open(out_file, 'w')
+
+    def __del__(self):
+        if self.file_handle is not stdout:
+            self.file_handle.close()
 
     def write(self):
         writer = self.__get_writer()
@@ -104,10 +107,6 @@ class Writer:
         headers, rows = self.__get_table_content(g)
         table_writer = tabulate(rows, headers=headers, tablefmt='html')
         self.file_handle.write(table_writer)
-
-    def close_file_handle(self):
-        if self.file_handle is not stdout:
-            self.file_handle.close()
 
     @staticmethod
     def __to_dict(g: object) -> Dict[str, Any]:


### PR DESCRIPTION
rename writer_func to writer_wrapper
move the decorator outside the Writer class
file_handle is an instance member
close_file_handle is an instance method
file_handle initialized in __init__, __get_file_handle not needed anymore